### PR TITLE
DM-12659: Clean up Doxygen tagfile imports

### DIFF
--- a/ups/jointcal_cholmod.cfg
+++ b/ups/jointcal_cholmod.cfg
@@ -19,6 +19,7 @@ config = lsst.sconsUtils.Configuration(
     __file__,
     headers=["src/*.h"],
     hasDoxygenInclude=False,
+    hasDoxygenTag=False,
     hasSwigFiles=False,
 )
 


### PR DESCRIPTION
This PR stops any package that imports `jointcal_cholmod` from expecting a Doxygen tag file.